### PR TITLE
[44기 신효민] ADD : productList 페이지 레이아웃 완성

### DIFF
--- a/public/data/list.json
+++ b/public/data/list.json
@@ -1,0 +1,90 @@
+[
+  {
+    "id": 1,
+    "name": "데스노트",
+    "post_image_url": "https://ticketimage.interpark.com/Play/image/large/23/23002291_p.gif",
+    "released_date": "2023-05-01",
+    "end_date": "2023-05-10",
+    "age_rated_id": 3,
+    "boarding_status_id": 2,
+    "booking_rating_total": 500,
+    "booking_rating_name": 150
+  },
+  {
+    "id": 2,
+    "name": "오페라의 유령",
+    "post_image_url": "https://ticketimage.interpark.com/Play/image/large/23/23000632_p.gif",
+    "released_date": "2023-05-08",
+    "end_date": "2023-05-21",
+    "age_rated_id": 2,
+    "boarding_status_id": 2,
+    "booking_rating_total": 500,
+    "booking_rating_name": 92
+  },
+  {
+    "id": 3,
+    "name": "맨오브 라만차",
+    "post_image_url": "https://t1.daumcdn.net/cfile/tistory/2223585055C9B02F2A",
+    "released_date": "2023-05-01",
+    "end_date": "2023-05-10",
+    "age_rated_id": 3,
+    "boarding_status_id": 1,
+    "booking_rating_total": 500,
+    "booking_rating_name": 48
+  },
+  {
+    "id": 4,
+    "name": "시카고",
+    "post_image_url": "https://ticketimage.interpark.com/Play/image/large/23/23004325_p.gif",
+    "released_date": "2023-05-01",
+    "end_date": "2023-05-10",
+    "age_rated_id": 4,
+    "boarding_status_id": 2,
+    "booking_rating_total": 500,
+    "booking_rating_name": 34
+  },
+  {
+    "id": 5,
+    "name": "레미제라블",
+    "post_image_url": "https://ticketimage.interpark.com/Play/image/large/19/19005246_p.gif",
+    "released_date": "2023-04-23",
+    "end_date": "2023-05-23",
+    "age_rated_id": 1,
+    "boarding_status_id": 1,
+    "booking_rating_total": 500,
+    "booking_rating_name": 66
+  },
+  {
+    "id": 6,
+    "name": "슈퍼클로젯",
+    "post_image_url": "https://img2.tmon.kr/cdn4/deals/2021/12/22/9402541394/original_9402541394_front_8fc8a_1640152380production.jpg",
+    "released_date": "2023-04-29",
+    "end_date": "2023-05-14",
+    "age_rated_id": 1,
+    "boarding_status_id": 1,
+    "booking_rating_total": 500,
+    "booking_rating_name": 21
+  },
+  {
+    "id": 7,
+    "name": "캣츠",
+    "post_image_url": "https://ticketimage.interpark.com/Play/image/large/23/23003680_p.gif",
+    "released_date": "2023-05-12",
+    "end_date": "2023-05-14",
+    "age_rated_id": 1,
+    "boarding_status_id": 2,
+    "booking_rating_total": 500,
+    "booking_rating_name": 53
+  },
+  {
+    "id": 8,
+    "name": "아이다",
+    "post_image_url": "https://ticketimage.interpark.com/Play/image/large/22/22001534_p.gif",
+    "released_date": "2023-05-10",
+    "end_date": "2023-05-14",
+    "age_rated_id": 1,
+    "boarding_status_id": 2,
+    "booking_rating_total": 500,
+    "booking_rating_name": 36
+  }
+]

--- a/src/config.js
+++ b/src/config.js
@@ -3,4 +3,5 @@ const BASE_URL = 'http://10.58.52.91:3000';
 export const API = {
   kakaoLogin: `${BASE_URL}/users/kakaologin`,
   kakaoAuthToken: 'https://kauth.kakao.com/oauth/token',
+  productList: `${BASE_URL}/musicals`,
 };

--- a/src/pages/ProductList/MusicalCard.js
+++ b/src/pages/ProductList/MusicalCard.js
@@ -1,0 +1,171 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const MusicalCard = ({ item }) => {
+  const bookingRate =
+    (item.booking_rating_name / item.booking_rating_total) * 100;
+
+  const ratedAge = age => {
+    const ageRate = {
+      4: '18',
+      3: '15',
+      2: '12',
+    };
+    return ageRate[age] || 'All';
+  };
+
+  return (
+    <CardWrap>
+      <Card>
+        <RankImage>
+          <MusicalRank rank={item.id}>No.{item.id}</MusicalRank>
+          <Thumbnail>
+            <img src={item.post_image_url} alt="뮤지컬 포스터" />
+            <FilmRating limit={item.age_rated_id}>
+              {ratedAge(item.age_rated_id)}
+            </FilmRating>
+          </Thumbnail>
+        </RankImage>
+        <CardContent>
+          <div>
+            <a>{item.name}</a>
+          </div>
+          <div>
+            <Rating>
+              예매율
+              <span>{bookingRate.toFixed(1)}%</span>
+            </Rating>
+          </div>
+          <Release>
+            <strong>{item.released_date}</strong>
+            <span>개봉</span>
+            <em>D-1</em>
+          </Release>
+        </CardContent>
+        <BookingBtn>예매하기</BookingBtn>
+      </Card>
+    </CardWrap>
+  );
+};
+const BookingBtn = styled.button`
+  width: 100%;
+  height: 30px;
+  padding: 5px 15px;
+  margin-top: 35px;
+  outline: 0;
+  border: 0;
+  background: linear-gradient(to right, #6200ee, #7c21ff);
+  border-radius: 5px;
+  color: white;
+  cursor: pointer;
+`;
+
+const Release = styled.span`
+  margin-top: 3px;
+  height: 13px;
+  color: #666666;
+  font-weight: 500;
+  white-space: nowrap;
+  font-size: 30px;
+
+  em {
+    margin-left: 5px;
+    font-size: 14px;
+    font-weight: bold;
+    color: #6200ee;
+  }
+`;
+
+const Rating = styled.strong`
+  font-size: 12px;
+  span {
+    margin-left: 10px;
+    color: #333333;
+    font-size: 30px;
+    font-weight: 500;
+  }
+`;
+
+const CardContent = styled.div`
+  a {
+    text-decoration: none;
+    font-weight: bold;
+  }
+  strong {
+    margin-right: 10px;
+  }
+  span {
+    color: #333333;
+    font-size: 14px;
+  }
+`;
+
+const Thumbnail = styled.div`
+  position: relative;
+  cursor: pointer;
+
+  img {
+    width: 100%;
+    height: 260px;
+    border-bottom-left-radius: 10px;
+    border-bottom-right-radius: 10px;
+  }
+`;
+
+const FilmRating = styled.i`
+  position: absolute;
+  top: 5px;
+  left: 5px;
+  background-color: ${({ limit }) => {
+    const ageLimit = {
+      4: '#FF0363',
+      3: '#F48131',
+      2: '#F5C951',
+    };
+    return ageLimit[limit] || '#36C640';
+  }};
+  font-size: 12px;
+  width: 22px;
+  height: 22px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: #ffffff;
+  font-weight: bold;
+  border-radius: 3px;
+`;
+
+const RankImage = styled.div`
+  width: 100%;
+  margin-bottom: 10px;
+`;
+
+const MusicalRank = styled.p`
+  height: 28px;
+  margin-bottom: 4px;
+  color: #ffffff;
+  background-color: ${({ rank }) => (rank > 4 ? '#252525' : '#7c21ff')};
+  font-size: 19px;
+  text-align: center;
+  line-height: 28px;
+  font-weight: 400;
+  border-top-left-radius: 10px;
+  border-top-right-radius: 10px;
+`;
+
+const Card = styled.li`
+  width: 197px;
+`;
+
+const CardWrap = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 15px;
+  padding: 15px;
+  border: 2px solid lightgrey;
+  border-radius: 20px;
+  box-shadow: 0 0 5px 3px rgba(211, 211, 211, 0.4);
+`;
+
+export default MusicalCard;

--- a/src/pages/ProductList/ProductList.js
+++ b/src/pages/ProductList/ProductList.js
@@ -1,7 +1,134 @@
 import React from 'react';
+import { useState } from 'react';
+import { useEffect } from 'react';
+import styled from 'styled-components';
+import MusicalCard from './MusicalCard';
+import { API } from '../../config';
 
 function ProductList() {
-  return <div />;
+  const [lists, setLists] = useState([]);
+  const [select, setSelect] = useState('');
+
+  const handleSelect = e => {
+    setSelect(e.target.value);
+  };
+  useEffect(() => {
+    fetch('/data/list.json', {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json;charset=utf-8',
+      },
+    })
+      .then(res => res.json())
+      .then(data => setLists(data));
+  }, []);
+
+  return (
+    <MusicalListWrap>
+      <ListTitle>
+        <h4>뮤지컬 차트</h4>
+      </ListTitle>
+      <SortTitle>
+        <NowShow>
+          <input type="checkbox" id="nowshowCheck" />
+          <span>현재 상영작만 보기</span>
+        </NowShow>
+        <SortType>
+          <select id="SortType" name="SortType" onChange={handleSelect}>
+            <option value="" selected>
+              예매율순
+            </option>
+            <option value="ageRateASC">연령별</option>
+            <option value="releasedDateASC">개봉일 오름차순</option>
+            <option value="releaseDateDESC">개봉일 내림차순</option>
+          </select>
+          <button>Go</button>
+        </SortType>
+      </SortTitle>
+      <MusicalChart>
+        <ol>
+          {lists?.map(item => {
+            return <MusicalCard item={item} key={item.id} />;
+          })}
+        </ol>
+      </MusicalChart>
+    </MusicalListWrap>
+  );
 }
+const MusicalChart = styled.div`
+  margin-top: 30px;
+
+  ol {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    padding: 0;
+    margin: 0;
+    list-style: none;
+  }
+`;
+
+const SortType = styled.div`
+  display: flex;
+  align-items: center;
+  select {
+    width: 120px;
+    padding: 3px 7px;
+    line-height: 27px;
+    border: 1px solid #b4b3aa;
+    border-radius: 5px;
+  }
+  button {
+    line-height: 19px;
+    font-weight: 500;
+    font-size: 12px;
+    border: 2px solid #7b7b7b;
+    border-radius: 5px;
+    color: #7b7b7b;
+    margin-left: 5px;
+    cursor: pointer;
+  }
+`;
+
+const NowShow = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 5px 1px;
+
+  input {
+    width: 18px;
+    height: 18px;
+  }
+
+  span {
+    margin-top: 2px;
+    margin-left: 5px;
+    font-size: 14px;
+  }
+`;
+
+const SortTitle = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  margin-top: 20px;
+`;
+
+const MusicalListWrap = styled.div`
+  width: 980px;
+  margin: 0 auto;
+  padding-bottom: 50px;
+`;
+
+const ListTitle = styled.div`
+  padding-top: 20px;
+  border-bottom: 3px solid #241d1e;
+
+  h4 {
+    font-size: 38px;
+    font-weight: 500;
+  }
+`;
 
 export default ProductList;


### PR DESCRIPTION
# ProductList(Musical List)

##### 1. ProductList

##### MusicalList 레이아웃

- map() 메서드를 활용하여 반복적인 뮤지컬 Card 들을 가독성 있게 표현
- checkbox 및 Select 태그를 활용해 정렬 선택 UI를 간편하게 표현

##### MusicalList 기능구현

- 현재 상영작 혹은 예매할 수 있는 모든 뮤지컬(현재 상영작 + 개봉 예정작)을 체크박스를 통해 lists 렌더링
- Select 태그의 Value값을 받아 QuaryParams를 보내 해당 Value에 대한 lists를 새로 받아 렌더링
- fetch 통신 API를 통해 list를 그리거나, Detail 페이지로 이동시키거나, 예매하기 페이지로 이동 시키기.

<br />

##### 2. 개발한 화면을 캡쳐해서 첨부 해 주세요. (drag & drop 또는 첨부파일 추가)

![스크린샷 2023-04-26 오전 11 58 55](https://user-images.githubusercontent.com/125179082/234455612-2561f67b-1cf5-4549-a506-89a468d57848.png)

<br />

##### 3. 이 브랜치에서 개발하면서 느꼇던 성장포인트를 적어주세요.

- 1차때 보다 점점 더 페이지를 예쁘게 꾸며볼 줄 알게 되는 것 같아서 재밌습니다.
- styled-component에 대해 점점 익숙해져 가는 것 같습니다.
