### PR TITLE
[44기 신효민] ADD : List 에서 Booking 및 Detail로 이동하는 Routing 설정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "slick-carousel": "^1.8.1",
         "styled-components": "^5.3.9",
         "styled-reset": "^4.4.6",
+        "swiper": "^9.2.4",
         "web-vitals": "^2.1.0",
         "zustand": "^4.3.7",
         "swiper": "^9.2.4"

--- a/src/pages/ProductList/MusicalCard.js
+++ b/src/pages/ProductList/MusicalCard.js
@@ -1,7 +1,9 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 const MusicalCard = ({ item }) => {
+  const navigate = useNavigate();
   const ratedAge = age => {
     const ageRate = {
       18: '18',
@@ -9,6 +11,14 @@ const MusicalCard = ({ item }) => {
       12: '12',
     };
     return ageRate[age] || 'All';
+  };
+
+  const goToDetail = musicalId => {
+    navigate(`/productdetail/detail/${musicalId}`);
+  };
+
+  const goToBooking = musical => {
+    navigate(`/booking`, { state: musical });
   };
 
   const compareDate = day => {
@@ -42,7 +52,11 @@ const MusicalCard = ({ item }) => {
       <Card>
         <RankImage>
           <MusicalRank rank={item.id}>No.{item.id}</MusicalRank>
-          <Thumbnail>
+          <Thumbnail
+            onClick={() => {
+              goToDetail(item.musicalId);
+            }}
+          >
             <img src={item.postImageUrl} alt="뮤지컬 포스터" />
             <FilmRating limit={item.ageRated}>
               {ratedAge(item.ageRated)}
@@ -65,7 +79,7 @@ const MusicalCard = ({ item }) => {
             <em>{compareDate(item.releasedDate)}</em>
           </Release>
         </CardContent>
-        <BookingBtn>예매하기</BookingBtn>
+        <BookingBtn onClick={() => goToBooking(item)}>예매하기</BookingBtn>
       </Card>
     </CardWrap>
   );


### PR DESCRIPTION
# productList(뮤지컬 List)

##### 1. productList

##### productList 에서 productDetail과 Booking 페이지 연결

- List에서 musicalCard의 이미지를 클릭시 해당 뮤지컬의 Detail 페이지로 이동 할 수 있도록 navigate 경로 설정
- List에서 musicalCard의 예매하기 버튼을 클릭시 해당 뮤지컬에 대한 예약페이지로 이동(이동시 navigate의 2번째 파라미터로 state에 객체를 넣어서 전달)

<br />

##### 2. 개발한 화면을 캡쳐해서 첨부 해 주세요. (drag & drop 또는 첨부파일 추가)

-

<br />

##### 3. 이 브랜치에서 개발하면서 느꼇던 성장포인트를 적어주세요.

- 
