### PR TITLE
[44기 김정환] Add: Booking 페이지 => 타 페이지에서 id 수신하여 선택값 적용 및 scrollIntoView 기능 추가

### DIFF
--- a/src/pages/Booking/Booking.js
+++ b/src/pages/Booking/Booking.js
@@ -11,22 +11,30 @@ import { format } from 'date-fns';
 
 function Booking() {
   const [bookingPageData, setBookingPageData] = useState([]);
-  const [bookingState, selectedDate, setTheatre, setTime, resetStore] =
-    useBookingStore(
-      state => [
-        state.bookingState,
-        state.bookingState.selectedDate,
-        state.setTheatre,
-        state.setTime,
-        state.reset,
-      ],
-      shallow
-    );
+  const [
+    bookingState,
+    selectedDate,
+    setMusical,
+    setTheatre,
+    setTime,
+    resetStore,
+  ] = useBookingStore(
+    state => [
+      state.bookingState,
+      state.bookingState.selectedDate,
+      state.setMusical,
+      state.setTheatre,
+      state.setTime,
+      state.reset,
+    ],
+    shallow
+  );
   const [searchParams, setSearchParams] = useSearchParams();
   const [seatSelectionStage, setSeatSelectionStage] = useState(false);
 
   const location = useLocation();
   let queryString = location.search;
+  let receivedState = location.state;
 
   useEffect(() => {
     fetch(`/data/booking/newBookingData${queryString}.json`, {
@@ -38,6 +46,19 @@ function Booking() {
       .then(response => response.json())
       .then(json => setBookingPageData(json));
   }, [queryString]);
+
+  useEffect(() => {
+    if (receivedState) {
+      console.log(receivedState);
+      handleDynamicFetch('musicalId', receivedState.musicalId);
+      setMusical({
+        id: receivedState.musicalId,
+        image: receivedState.postImageUrl,
+        title: receivedState.musicalName,
+        ageLimit: receivedState.ageRated,
+      });
+    }
+  }, []);
 
   const handleResetClick = () => {
     setSearchParams([]);
@@ -104,6 +125,7 @@ function Booking() {
           <BookingFirstStep
             handleDynamicFetch={handleDynamicFetch}
             bookingPageData={bookingPageData}
+            receivedState={receivedState}
           />
         )}
         <BookingProgress

--- a/src/pages/Booking/BookingFirstStep.js
+++ b/src/pages/Booking/BookingFirstStep.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import styled, { css } from 'styled-components';
 import MusicalItem from './MusicalBooking/MusicalItem';
 import TheatreItem from './MusicalBooking/TheatreItem';
@@ -6,16 +6,37 @@ import Calendar from './MusicalBooking/Calendar/Calendar';
 import TimeItem from './MusicalBooking/TimeItem';
 import { useBookingStore } from './store/store';
 
-function BookingFirstStep({ handleDynamicFetch, bookingPageData }) {
+function BookingFirstStep({
+  handleDynamicFetch,
+  bookingPageData,
+  receivedState,
+}) {
   const bookingState = useBookingStore(state => state.bookingState);
   const { selectedMusical, selectedTheatre, selectedDate, selectedTime } =
     bookingState;
+
+  const stepBodyRef = useRef(null);
+
+  useEffect(() => {
+    if (selectedMusical && stepBodyRef.current) {
+      const selectedItem = bookingPageData[0]?.findIndex(
+        musical => musical.musicalId === selectedMusical.id
+      );
+      setTimeout(() => {
+        stepBodyRef?.current?.children[selectedItem]?.scrollIntoView({
+          behavior: 'smooth',
+          block: 'nearest',
+          inline: 'start',
+        });
+      }, 500);
+    }
+  }, [selectedMusical, bookingPageData[0]]);
 
   return (
     <BookingStepsContainer>
       <BookingStep width="33.3">
         <StepHeader>상영중인 작품</StepHeader>
-        <StepBody $scrollable>
+        <StepBody ref={stepBodyRef} $scrollable>
           {bookingPageData[0]?.map(
             ({
               musicalId,
@@ -34,6 +55,7 @@ function BookingFirstStep({ handleDynamicFetch, bookingPageData }) {
                 ageLimit={ageLimit}
                 rate={reservationRate}
                 releasedDate={releasedDate}
+                data-id={musicalId}
               />
             )
           )}

--- a/src/pages/Main/Contents/MusicalChartList.js
+++ b/src/pages/Main/Contents/MusicalChartList.js
@@ -30,7 +30,7 @@ function MusicalChartList({ item, index }) {
           {onPoster && (
             <HoverView>
               <TicketBtnWrap>
-                <Link key={item.musicalId} to="/booking">
+                <Link key={item.musicalId} to="/booking" state={item}>
                   <TicketBtn>예매하기</TicketBtn>
                 </Link>
                 <Link


### PR DESCRIPTION
--

##### 1. Booking 페이지가 마운트될 시, 만약 이전 경로가 뮤지컬 리스트나 상세 페이지이며 해당 특정 뮤지컬의 "예매하기" 버튼을 눌러서 온다면, useNavigate/Link 의 state prop을 해당 뮤지컬의 정보로 받아, 해당 id와 동일한 아이템을 예매 과정에 적용하고 해당 정보로 store를 업데이트하는 기능을 구현했습니다. 

<br />

##### 2. 개발한 화면을 캡쳐해서 첨부 해 주세요. (drag & drop 또는 첨부파일 추가)

![Screenshot 2023-05-02 at 2 35 00 PM](https://user-images.githubusercontent.com/37966668/235587174-7e65bf93-674d-4fc1-a2de-0a345c1cb7eb.png)

<br />

##### 3. 이 브랜치에서 개발하면서 느꼇던 성장포인트를 적어주세요.

- Link/useNavigate에서 state prop을 받아 사용하는 기능을 복습할 수 있었습니다.
- scrollIntoView를 처음 써보면서 배우는 기회를 얻게 되었습니다.

  <br />
