### PR TITLE
[44기 김정환] Add: 예매 => 결제 넘어갈 때 스토어에 필요한 정보값 추가, 해당 정보 세션 스토리지에 저장

### DIFF
--- a/src/pages/Booking/BookingSecondStep.js
+++ b/src/pages/Booking/BookingSecondStep.js
@@ -20,7 +20,9 @@ function BookingSecondStep() {
       'Content-Type': 'application/json',
     })
       .then(response => response.json())
-      .then(result => setBookedSeatsData(result));
+      .then(result => {
+        setBookedSeatsData(result[3]?.bookedSeatsData);
+      });
   }, []);
 
   return (

--- a/src/pages/Booking/MusicalBooking/BookingProgress/BookingProgress.js
+++ b/src/pages/Booking/MusicalBooking/BookingProgress/BookingProgress.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 import { useBookingStore } from '../../store/store';
 import { ChevronRight } from 'react-feather';
@@ -22,6 +23,18 @@ function BookingProgress({ seatSelectionStage, setSeatSelectionStage }) {
     18: 18,
     15: 15,
     12: 12,
+  };
+
+  const userData = {
+    ...bookingStatus,
+    selectedDate: format(bookingStatus.selectedDate, 'yyyy-MM-dd'),
+  };
+
+  const navigate = useNavigate();
+
+  const handleMoveToPayment = () => {
+    sessionStorage.setItem('userData', JSON.stringify(userData));
+    navigate('/payment');
   };
   return (
     <BookingProgressStatusBar>
@@ -98,7 +111,11 @@ function BookingProgress({ seatSelectionStage, setSeatSelectionStage }) {
         </BookingStepsContainer>
       </div>
       <BookingButton
-        onClick={() => setSeatSelectionStage(true)}
+        onClick={
+          seatSelectionStage === true
+            ? handleMoveToPayment
+            : () => setSeatSelectionStage(true)
+        }
         isActive={firstStepsComplete ? true : false}
       >
         {seatSelectionStage ? '결제하기' : '좌석 선택하기'}

--- a/src/pages/Booking/SeatBooking/Counter.js
+++ b/src/pages/Booking/SeatBooking/Counter.js
@@ -4,7 +4,7 @@ import { Minus, Plus } from 'react-feather';
 
 function Counter({ ticketCount, setTicketCount }) {
   const handleCounter = num => {
-    if (ticketCount + num === 0) {
+    if (ticketCount + num === 0 || ticketCount + num === 7) {
       return;
     }
     setTicketCount(ticketCount + num);
@@ -26,6 +26,10 @@ function Counter({ ticketCount, setTicketCount }) {
           <Plus />
         </Button>
       </ActualCounter>
+      <LimitInfo>
+        한번에 예약 시 <span>최대 6명</span>까지
+        <br /> 예약 가능합니다.
+      </LimitInfo>
     </CounterContainer>
   );
 }
@@ -85,5 +89,20 @@ const CounterNum = styled.div`
     margin-right: 2px;
     font-size: 26px;
     font-weight: bold;
+  }
+`;
+
+const LimitInfo = styled.div`
+  white-space: pre-wrap;
+  white-space: pre-line;
+  word-wrap: break-word;
+  margin-top: 10px;
+  font-size: 10px;
+  color: #e8e8e8;
+
+  span {
+    opacity: 1;
+    font-weight: 600;
+    color: #fff;
   }
 `;

--- a/src/pages/Booking/SeatBooking/SelectedSeatsInfo.js
+++ b/src/pages/Booking/SeatBooking/SelectedSeatsInfo.js
@@ -1,10 +1,15 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import styled, { css } from 'styled-components';
 import { useBookingStore } from '../store/store';
+import { shallow } from 'zustand/shallow';
 
 function SelectedSeatsInfo({ vipPrice, regPrice }) {
-  const selectedSeats = useBookingStore(
-    state => state.bookingState.selectedSeats.seatValues
+  const [selectedSeats, setTotalAmount] = useBookingStore(
+    state => [
+      state.bookingState.selectedSeats.seatValues,
+      state.setTotalAmount,
+    ],
+    shallow
   );
   const vipSeatCount = selectedSeats?.filter(
     seat => seat.startsWith('A') || seat.startsWith('B') || seat.startsWith('C')
@@ -13,6 +18,7 @@ function SelectedSeatsInfo({ vipPrice, regPrice }) {
   const regSeatCount = selectedSeats?.length - vipSeatCount;
   const totalVipPrice = vipSeatCount * vipPrice;
   const totalRegPrice = regSeatCount * regPrice;
+  const totalCost = totalVipPrice + totalRegPrice;
 
   const checkVip = value => {
     if (
@@ -25,6 +31,10 @@ function SelectedSeatsInfo({ vipPrice, regPrice }) {
       return false;
     }
   };
+
+  useEffect(() => {
+    setTotalAmount(totalVipPrice + totalRegPrice);
+  }, [totalCost]);
 
   return (
     <SelectedSeatsContainer>
@@ -55,7 +65,7 @@ function SelectedSeatsInfo({ vipPrice, regPrice }) {
 
           <TotalPrice>
             <div>총&nbsp;&nbsp;</div>
-            {(totalVipPrice + totalRegPrice)?.toLocaleString()}&nbsp;
+            {totalCost.toLocaleString()}&nbsp;
             <span>원</span>
           </TotalPrice>
         </SeatsAndPriceContainer>

--- a/src/pages/Booking/store/store.js
+++ b/src/pages/Booking/store/store.js
@@ -6,6 +6,7 @@ const initialState = {
   selectedDate: new Date(),
   selectedTime: null,
   selectedSeats: [],
+  totalAmount: 0,
 };
 
 export const useBookingStore = create(set => ({
@@ -52,6 +53,15 @@ export const useBookingStore = create(set => ({
       bookingState: {
         ...state.bookingState,
         selectedSeats: seatsValues,
+      },
+    }));
+  },
+  setTotalAmount: value => {
+    set(state => ({
+      ...state,
+      bookingState: {
+        ...state.bookingState,
+        totalAmount: value,
       },
     }));
   },


### PR DESCRIPTION

##### 1. 예매에서 결제 페이지로 넘어갈 때, zustand 스토어에 있는 사용자가 선택한 예매 관련 정보들(e.g. 예매 플로우 중 선택한 뮤지컬, 상영관, 좌석들 등등)을 payment 페이지에서 사용할 수 있도록 sessionStorage에 저장하는 기능을 추가하였습니다.

<br />

##### 2. 개발한 화면을 캡쳐해서 첨부 해 주세요. (drag & drop 또는 첨부파일 추가)

![Screenshot 2023-05-02 at 3 50 31 PM](https://user-images.githubusercontent.com/37966668/235599311-fe83e579-e495-4241-9955-77b21c3c208e.png)

<br />

##### 3. 이 브랜치에서 개발하면서 느꼇던 성장포인트를 적어주세요.

- (예시) store가 있어서 참 간편하다고 느꼈습니다. (남용하면 안되겠다는 점도 느꼈습니다.)
  <br />
